### PR TITLE
Removed date timestamp from make_lpd_conf.in to support reproducibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,6 @@ Makefile
 /UTILS/lpq_in_perl
 /UTILS/lpr_in_perl
 /UTILS/lprm_in_perl
-/UTILS/make_lpd_conf
 /UTILS/make_printcap_use
 /UTILS/makeinc
 /UTILS/read_conf

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ Makefile
 /UTILS/lpq_in_perl
 /UTILS/lpr_in_perl
 /UTILS/lprm_in_perl
+/UTILS/make_lpd_conf
 /UTILS/make_printcap_use
 /UTILS/makeinc
 /UTILS/read_conf

--- a/UTILS/make_lpd_conf.in
+++ b/UTILS/make_lpd_conf.in
@@ -2,7 +2,7 @@
 date=`LC_ALL=C date`;
 AWK=@AWK@
 cat <<EOF
-# lpd.conf generated for version $1 compiled on $date
+# lpd.conf generated for version $1
 #   The values in this file are the built-in default values. (Which may depend
 #   on the build-options used when your LPRng was compiled).
 #   If you modify the file,  set the value to something other than the default


### PR DESCRIPTION
Hello, I'm submitting this change in order to further the reproducible builds agenda - which aims to ensure all projects built remain bit-by-bit identical uniformly throughout the package.

In this case, a date being printed within make_lpd_conf.in that would be generated in an html output was causing this build to not be building in a reproducible fashion.